### PR TITLE
feat(action): add support for multiple docker bake targets

### DIFF
--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -9,7 +9,7 @@
 name: docker-buildx-bake-hubdocker-latest
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-docker-buildx-bake-hubdocker-latest
+  group: ${{ github.workflow }}-${{ github.ref }}-docker-buildx-bake-hubdocker-${{ inputs.docker_bake_targets }}-latest
   # cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
   cancel-in-progress: false
 
@@ -21,11 +21,36 @@ on:
         default: false
         required: false
         type: boolean
+      docker_bake_targets:
+        description: 'docker bake targets'
+        default: 'image-basic'
+        required: false
+        type: string
+      docker-metadata-flavor-suffix:
+        description: 'docker metadata flavor suffix just like: -alpine -debian'
+        default: ''
+        required: false
+        type: string
+      docker_bake_matrix_target_postfix:
+        description: 'docker build matrix target postfix'
+        default: '-all'
+        required: false
+        type: string
       docker_bake_config_file_path:
         description: 'docker-bake file name'
         default: './docker-bake.hcl'
         required: false
         type: string
+      docker-build-no-cache:
+        description: 'docker build no cache'
+        default: false
+        required: false
+        type: boolean
+      docker-build-timeout-minutes:
+        description: 'docker build timeout minutes'
+        default: 30
+        required: false
+        type: number
     secrets:
       DOCKERHUB_TOKEN:
         description: 'docker hub token'
@@ -49,7 +74,7 @@ jobs:
         name: Create matrix
         id: platforms
         run: |
-          echo "matrix=$(docker buildx bake image-all --print | jq -cr '.target."image-all".platforms')" >>${GITHUB_OUTPUT}
+          echo "matrix=$(docker buildx bake ${{ inputs.docker_bake_targets }}${{inputs.docker_bake_matrix_target_postfix}} --print | jq -cr '.target."${{ inputs.docker_bake_targets }}${{inputs.docker_bake_matrix_target_postfix}}".platforms')" >>${GITHUB_OUTPUT}
       -
         name: Show matrix
         run: |
@@ -84,18 +109,23 @@ jobs:
           tags: |
             # set latest tag for main branch https://github.com/docker/metadata-action#latest-tag
             type=raw,value=latest,enable=true
+          flavor: |
+            latest=auto
+            suffix=${{ inputs.docker-metadata-flavor-suffix }}
+
       -
         name: Rename meta bake definition file
         run: |
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/bake-meta.json"
+          mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
         uses: actions/upload-artifact@v4
         if: ${{ inputs.push_remote_flag }}
         with:
-          name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/bake-meta.json
+          name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -120,15 +150,24 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
+        timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/bake-meta.json
-          targets: image
-          no-cache: true
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          targets: ${{ inputs.docker_bake_targets }}
+          no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
           sbom: false
           push: ${{ inputs.push_remote_flag }}
@@ -139,19 +178,26 @@ jobs:
             *.cache-to=type=gha,scope=build-${{ env.PLATFORM_PAIR }}
             *.output=type=image,"name=${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}",push-by-digest=true,name-canonical=true
 
+      - name: Extract container image digest from bake output
+        id: bake-output-container-image-digest
+        run: |
+          echo "digest=$(echo '${{ steps.bake.outputs.metadata}}' | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]')" >>$GITHUB_OUTPUT
+
       -
         name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.digest'] }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+          digest="${{ steps.bake-output-container-image-digest.outputs.digest }}"
+          touch "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/${digest#sha256:}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+
       -
         name: Upload digest
         uses: actions/upload-artifact@v4
         if: ${{ inputs.push_remote_flag }}
         with:
-          name: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/digests/*
+          name: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/*
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -159,8 +205,8 @@ jobs:
       -
         name: check temp config files
         run: |
-          ls -al ${{ runner.temp }}
-          ls -al ${{ runner.temp }}/digests/
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
 
 
   merge:
@@ -173,7 +219,8 @@ jobs:
       -
         name: check temp path
         run: |
-          ls -al ${{ runner.temp }}
+          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
 
       -
         name: Download meta bake definition
@@ -181,8 +228,8 @@ jobs:
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
-          pattern: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-*
-          path: ${{ runner.temp }}
+          pattern: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           merge-multiple: true
 
       -
@@ -191,15 +238,15 @@ jobs:
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
-          pattern: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-*
-          path: ${{ runner.temp }}/digests/
+          pattern: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
           merge-multiple: true
 
       -
         name: check temp config files
         run: |
-          ls -al ${{ runner.temp }}
-          ls -al ${{ runner.temp }}/digests/
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
 
       -
         name: Set up Docker Buildx
@@ -214,12 +261,12 @@ jobs:
 
       -
         name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests/
+        working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -9,7 +9,7 @@
 name: docker-buildx-bake-hubdocker-tag
 
 # concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}-docker-buildx-bake-hubdocker-tag
+#   group: ${{ github.workflow }}-${{ github.ref }}-docker-buildx-bake-hubdocker-${{ inputs.docker_bake_targets }}-tag
 #   cancel-in-progress: false
 
 on:
@@ -20,11 +20,36 @@ on:
         default: true
         required: false
         type: boolean
+      docker_bake_targets:
+        description: 'docker bake targets'
+        default: 'image-basic'
+        required: false
+        type: string
+      docker-metadata-flavor-suffix:
+        description: 'docker metadata flavor suffix just like: -alpine -debian'
+        default: ''
+        required: false
+        type: string
+      docker_bake_matrix_target_postfix:
+        description: 'docker build matrix target postfix'
+        default: '-all'
+        required: false
+        type: string
       docker_bake_config_file_path:
         description: 'docker-bake file name'
         default: './docker-bake.hcl'
         required: false
         type: string
+      docker-build-no-cache:
+        description: 'docker build no cache'
+        default: false
+        required: false
+        type: boolean
+      docker-build-timeout-minutes:
+        description: 'docker build timeout minutes'
+        default: 30
+        required: false
+        type: number
     secrets:
       DOCKERHUB_TOKEN:
         description: 'docker hub token'
@@ -48,7 +73,7 @@ jobs:
         name: Create matrix
         id: platforms
         run: |
-          echo "matrix=$(docker buildx bake image-all --print | jq -cr '.target."image-all".platforms')" >>${GITHUB_OUTPUT}
+          echo "matrix=$(docker buildx bake ${{ inputs.docker_bake_targets }}${{inputs.docker_bake_matrix_target_postfix}} --print | jq -cr '.target."${{ inputs.docker_bake_targets }}${{inputs.docker_bake_matrix_target_postfix}}".platforms')" >>${GITHUB_OUTPUT}
       -
         name: Show matrix
         run: |
@@ -83,18 +108,23 @@ jobs:
           tags: |
             # type semver https://github.com/docker/metadata-action#typesemver
             type=semver,pattern={{version}}
+          flavor: |
+            latest=auto
+            suffix=${{ inputs.docker-metadata-flavor-suffix }}
+
       -
         name: Rename meta bake definition file
         run: |
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/bake-meta.json"
+          mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
         uses: actions/upload-artifact@v4
         if: ${{ inputs.push_remote_flag }}
         with:
-          name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/bake-meta.json
+          name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -119,15 +149,24 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
+        timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/bake-meta.json
-          targets: image
-          no-cache: true
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          targets: ${{ inputs.docker_bake_targets }}
+          no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
           sbom: false
           push: ${{ inputs.push_remote_flag }}
@@ -138,19 +177,26 @@ jobs:
             *.cache-to=type=gha,scope=build-${{ env.PLATFORM_PAIR }}
             *.output=type=image,"name=${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}",push-by-digest=true,name-canonical=true
 
+      - name: Extract container image digest from bake output
+        id: bake-output-container-image-digest
+        run: |
+          echo "digest=$(echo '${{ steps.bake.outputs.metadata}}' | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]')" >>$GITHUB_OUTPUT
+
       -
         name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.digest'] }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+          digest="${{ steps.bake-output-container-image-digest.outputs.digest }}"
+          touch "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/${digest#sha256:}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+
       -
         name: Upload digest
         uses: actions/upload-artifact@v4
         if: ${{ inputs.push_remote_flag }}
         with:
-          name: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/digests/*
+          name: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/*
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -158,8 +204,8 @@ jobs:
       -
         name: check temp config files
         run: |
-          ls -al ${{ runner.temp }}
-          ls -al ${{ runner.temp }}/digests/
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
 
 
   merge:
@@ -172,7 +218,8 @@ jobs:
       -
         name: check temp path
         run: |
-          ls -al ${{ runner.temp }}
+          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
 
       -
         name: Download meta bake definition
@@ -180,8 +227,8 @@ jobs:
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
-          pattern: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-*
-          path: ${{ runner.temp }}
+          pattern: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           merge-multiple: true
 
       -
@@ -190,15 +237,15 @@ jobs:
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
-          pattern: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-*
-          path: ${{ runner.temp }}/digests/
+          pattern: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
           merge-multiple: true
 
       -
         name: check temp config files
         run: |
-          ls -al ${{ runner.temp }}
-          ls -al ${{ runner.temp }}/digests/
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
 
       -
         name: Set up Docker Buildx
@@ -213,12 +260,12 @@ jobs:
 
       -
         name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests/
+        working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR ${GO_PATH_SOURCE_DIR}
 RUN mkdir -p ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME}
 COPY $PWD ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME}
 
-RUN go install -v github.com/convention-change/zymosis/cmd/zymosis@latest
+RUN go install -v github.com/convention-change/zymosis/cmd/zymosis@v1.1.3
 RUN cd ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME} && \
     zymosis -g go
 

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -20,7 +20,7 @@ COPY $PWD ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME}
 RUN go env -w "GOPROXY=https://goproxy.cn,direct"
 RUN go env -w "GOPRIVATE='*.gitlab.com,*.gitee.com"
 
-RUN go install -v github.com/convention-change/zymosis/cmd/zymosis@latest
+RUN go install -v github.com/convention-change/zymosis/cmd/zymosis@v1.1.3
 RUN cd ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME} && \
     zymosis -g go
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -12,8 +12,13 @@ group "default" {
   targets = ["image-local"]
 }
 
-target "image" {
+// this config use by `docker_bake_targets` most of time is `image-basic`
+// https://docs.docker.com/build/bake/reference/#target
+// show config as: docker buildx bake --print image-basic
+target "image-basic" {
   inherits = ["docker-metadata-action"]
+  context = "."
+  dockerfile = "Dockerfile"
 }
 
 target "image-local" {
@@ -21,22 +26,28 @@ target "image-local" {
   output = ["type=docker"]
 }
 
+# // this config use by `docker_bake_matrix_target_postfix` most of time is {targets}-all
+# // https://docs.docker.com/build/bake/reference/#target
 # // must check by parent image support multi-platform
 # // doc: https://docs.docker.com/reference/cli/docker/buildx/build/#platform
 # // most of can as: linux/amd64 linux/386 linux/arm64/v8 linux/arm/v7 linux/arm/v6 linux/ppc64le linux/s390x
-# target "image-all" {
-#   inherits = ["image"]
+# // show config as: docker buildx bake --print image-basic-all
+# target "image-basic-all" {
+#   inherits = ["image-basic"]
 #   platforms = [
 #     "linux/amd64",
 #     "linux/arm64/v8"
 #   ]
 # }
 
+// this config use by `docker_bake_matrix_target_postfix` most of time is {targets}-all
+// https://docs.docker.com/build/bake/reference/#target
 // must check by parent image support multi-platform
 // doc: https://docs.docker.com/reference/cli/docker/buildx/build/#platform
-// golang with alpine can use as: linux/amd64 linux/386 linux/arm64/v8 linux/arm/v7 linux/ppc64le linux/s390x
-target "image-all" {
-  inherits = ["image"]
+// most of can as: linux/amd64 linux/386 linux/arm64/v8 linux/arm/v7 linux/arm/v6 linux/ppc64le linux/s390x
+// show config as: docker buildx bake --print image-basic-all
+target "image-basic-all" {
+  inherits = ["image-basic"]
   platforms = [
     "linux/amd64",
     "linux/386",


### PR DESCRIPTION
feat #28

- Add inputs for docker_bake_targets, docker_metadata_flavor_suffix, and docker_bake_matrix_target_postfix
- Update matrix creation to use new input variables
- Modify build process to support multiple targets
- Add extract container image digest step
- Update artifact names to include docker_bake_targets
- Create separate directories for each docker_bake_targets
