### PR TITLE
build: comment out zymosis installation and execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ WORKDIR ${GO_PATH_SOURCE_DIR}
 RUN mkdir -p ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME}
 COPY $PWD ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME}
 
-RUN go install -v github.com/convention-change/zymosis/cmd/zymosis@v1.1.3
-RUN cd ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME} && \
-    zymosis -g go
+#RUN go install -v github.com/convention-change/zymosis/cmd/zymosis@v1.1.3
+#RUN cd ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME} && \
+#    zymosis -g go
 
 RUN cd ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME} && \
     go mod download -x

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -20,9 +20,9 @@ COPY $PWD ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME}
 RUN go env -w "GOPROXY=https://goproxy.cn,direct"
 RUN go env -w "GOPRIVATE='*.gitlab.com,*.gitee.com"
 
-RUN go install -v github.com/convention-change/zymosis/cmd/zymosis@v1.1.3
-RUN cd ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME} && \
-    zymosis -g go
+#RUN go install -v github.com/convention-change/zymosis/cmd/zymosis@v1.1.3
+#RUN cd ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME} && \
+#    zymosis -g go
 
 RUN cd ${GO_PATH_SOURCE_DIR}/${GO_ENV_PACKAGE_NAME} && \
     go mod download -x


### PR DESCRIPTION
- Commented out zymosis installation and execution commands in both build.dockerfile and Dockerfile
- This change allows the Dockerfile to complete the go mod download step without errors
